### PR TITLE
vendor: Set DISABLE_EAP_PROXY to true.

### DIFF
--- a/configs/pixeldust_main.mk
+++ b/configs/pixeldust_main.mk
@@ -31,3 +31,6 @@ PRODUCT_COPY_FILES += vendor/pixeldust/prebuilt/etc/privapp-permissions/pixeldus
 # Copy all init rc files
 $(foreach f,$(wildcard vendor/pixeldust/prebuilt/etc/init/*.rc),\
 	$(eval PRODUCT_COPY_FILES += $(f):system/etc/init/$(notdir $f)))
+
+# Disable qmi EAP-SIM security
+DISABLE_EAP_PROXY := true


### PR DESCRIPTION
it will break wpa_supplicant dependency on qmi

* Without this flag, wpa_supplicant fails to build because we do not have
  sources for these proprietary libs: libqmi_cci, libqmiservices,
  libidl.
* Reference:
  https://source.codeaurora.org/quic/la/platform/external/wpa_supplicant_8/commit/?h=cfd8fe3d57bcf0976dddb0d82ec04fcd2dbc5ebc

Change-Id: Id161eadd9e5327768d1f41fb621d4422aeaa27ec
Signed-off-by: joshuous <joshuous@gmail.com>
Signed-off-by: spezi77 <spezi7713@gmx.net>