### PR TITLE
Fix WLAN path Typo

### DIFF
--- a/build/core/qcom_target.mk
+++ b/build/core/qcom_target.mk
@@ -19,7 +19,7 @@ $(call set-device-specific-path,DATA_IPA_CFG_MGR,data-ipa-cfg-mgr,vendor/qcom/op
 $(call set-device-specific-path,DATASERVICES,dataservices,vendor/qcom/opensource/dataservices)
 $(call set-device-specific-path,THERMAL,thermal,hardware/qcom/thermal)
 $(call set-device-specific-path,VR,vr,hardware/qcom/vr)
-$(call set-device-specific-path,WLAN,wlan,hardware/qcom/wlan-caf)
+$(call set-device-specific-path,WLAN,wlan,hardware/qcom-caf/wlan)
 
 PRODUCT_CFI_INCLUDE_PATHS += \
     hardware/qcom-caf/wlan/qcwcn/wpa_supplicant_8_lib


### PR DESCRIPTION
fix Wlan dependencies error while compiling
demo error:
external/wpa_supplicant_8/hostapd/Android.mk: error: "hostapd (EXECUTABLES android-arm64) missing lib_driver_cmd_qcwcn (STATIC_LIBRARIES android-arm64)"
frameworks/opt/net/wifi/libwifi_hal/Android.mk: error: "libwifi-hal (SHARED_LIBRARIES android-arm64) missing libwifi-hal-qcom (STATIC_LIBRARIES android-arm64)"